### PR TITLE
Add macOS build support and cross-platform refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Use clang++ as the compiler
+# Homebrew on Apple Silicon installs to /opt/homebrew (Intel Macs use /usr/local).
+# Neither prefix is on the default compiler / linker search path, so the project's
+# bare-name target_link_libraries calls and #include directives need help here.
+if(APPLE)
+  include_directories(/opt/homebrew/include)
+  link_directories(/opt/homebrew/lib)
+endif()
 find_program(CLANG_EXECUTABLE clang)
 find_program(CLANGXX_EXECUTABLE clang++)
 set(CMAKE_C_COMPILER clang CACHE STRING "C compiler" FORCE)
@@ -20,6 +27,15 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   message(STATUS "Lib installation directory: " ${CMAKE_INSTALL_LIBDIR})
   message(STATUS "Data installation directory: " ${CMAKE_INSTALL_DATADIR})
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+
+# macOS installs binaries to /usr/local/bin and the resources alongside them
+# so that getResourceDir()'s "<exec_dir>/resources" lookup finds them.
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CMAKE_INSTALL_BINDIR "/usr/local/bin")
+  set(CMAKE_INSTALL_DATADIR "/usr/local/bin/resources")
+  message(STATUS "Bin installation directory: " ${CMAKE_INSTALL_BINDIR})
+  message(STATUS "Data installation directory: " ${CMAKE_INSTALL_DATADIR})
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/../bin)
 message(STATUS "Executable output directory: " ${EXECUTABLE_OUTPUT_PATH})
@@ -299,13 +315,14 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Windows") 
 
-# boost_chrono boost_file_system boost_iostreams  z are required by ProteoWizard
-# boost_serialization xerces-c z are required by toppic suite
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_link_libraries(topfd boost_chrono boost_filesystem boost_program_options 
+# Linux and macOS share the same dependency list and link flags. boost_chrono,
+# boost_filesystem, boost_iostreams and z are required by ProteoWizard;
+# boost_serialization, xerces-c and z are required by the rest of the suite.
+if(UNIX)
+  target_link_libraries(topfd boost_chrono boost_filesystem boost_program_options
     boost_iostreams boost_thread xerces-c sqlite3 z onnxruntime)
 
-  target_link_libraries(topindex boost_program_options 
+  target_link_libraries(topindex boost_program_options
     boost_serialization xerces-c z)
 
   target_link_libraries(toppic boost_program_options
@@ -317,29 +334,35 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(topdiff boost_program_options
     sqlite3 xerces-c z)
 
-  target_link_libraries(topdia boost_chrono boost_filesystem boost_program_options 
+  target_link_libraries(topdia boost_chrono boost_filesystem boost_program_options
     boost_iostreams boost_thread xerces-c sqlite3 z onnxruntime)
 
-  target_link_libraries(topfd_gui Qt5Widgets Qt5Core Qt5Gui xerces-c sqlite3)
+  target_link_libraries(topfd_gui Qt5::Widgets Qt5::Core Qt5::Gui
+    xerces-c sqlite3)
 
-  target_link_libraries(topindex_gui Qt5Widgets Qt5Core Qt5Gui
-    boost_program_options  xerces-c)
+  target_link_libraries(topindex_gui Qt5::Widgets Qt5::Core Qt5::Gui
+    boost_program_options xerces-c)
 
-  target_link_libraries(toppic_gui Qt5Widgets Qt5Core Qt5Gui 
-    boost_program_options  xerces-c)
+  target_link_libraries(toppic_gui Qt5::Widgets Qt5::Core Qt5::Gui
+    boost_program_options xerces-c)
 
-  target_link_libraries(topmg_gui Qt5Widgets Qt5Core Qt5Gui 
-    boost_program_options  xerces-c)
+  target_link_libraries(topmg_gui Qt5::Widgets Qt5::Core Qt5::Gui
+    boost_program_options xerces-c)
 
-  target_link_libraries(topdiff_gui Qt5Widgets Qt5Core Qt5Gui
-    boost_program_options  xerces-c)
+  target_link_libraries(topdiff_gui Qt5::Widgets Qt5::Core Qt5::Gui
+    boost_program_options xerces-c)
 
-  target_link_libraries(topdia_gui Qt5Widgets Qt5Core Qt5Gui 
+  target_link_libraries(topdia_gui Qt5::Widgets Qt5::Core Qt5::Gui
     boost_program_options xerces-c sqlite3)
 
-  install (TARGETS topfd topindex toppic topmg topdiff topdia topfd_gui topindex_gui
-    toppic_gui topmg_gui topdiff_gui topdia_gui DESTINATION ${CMAKE_INSTALL_BINDIR})
-  install (DIRECTORY lib/toppic/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  install (DIRECTORY resources/ DESTINATION ${CMAKE_INSTALL_DATADIR})
+  install(TARGETS topfd topindex toppic topmg topdiff topdia
+    topfd_gui topindex_gui toppic_gui topmg_gui topdiff_gui topdia_gui
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(DIRECTORY resources/ DESTINATION ${CMAKE_INSTALL_DATADIR})
+endif()
 
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux") 
+# Bundled libonnxruntime.so is shipped only for Linux; macOS uses the system
+# Homebrew dylib and Windows uses the bundled .dll handled in its own block.
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  install(DIRECTORY lib/toppic/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/README.md
+++ b/README.md
@@ -91,3 +91,19 @@ export LANGUAGE=en_US.UTF-8
 
 [MSYS2](http://www.msys2.org/) is used for building TopPIC Suite on Windows systems. Please follow the instructions from [here](doc/windows_build.md).
 
+### Building on MacOS
+
+```sh
+# install compiling tools and dependencies
+brew install boost xerces-c sqlite3 zlib onnxruntime rapidjson cmake
+
+# install Qt5 for GUI
+brew install qt@5
+
+# building
+mkdir build
+cd build
+cmake ..
+make -j$(sysctl -n hw.ncpu)
+make install
+```

--- a/src/common/util/file_util.cpp
+++ b/src/common/util/file_util.cpp
@@ -20,6 +20,9 @@
 
 #if defined (_WIN32) || defined (_WIN64) || defined (__MINGW32__) || defined (__MINGW64__)
 #include <windows.h>
+#elif defined (__APPLE__)
+#include <climits>
+#include <mach-o/dyld.h>
 #else
 #include <unistd.h>
 #endif
@@ -46,6 +49,10 @@ std::string getExecutiveDir(const std::string &argv_0) {
   LPSTR lpFilePart;
   char file_name[MAX_PATH];
   SearchPath(NULL, argv_0.c_str(), ".exe", MAX_PATH, file_name, &lpFilePart);
+#elif defined (__APPLE__)
+  char file_name[PATH_MAX];
+  uint32_t size = sizeof(file_name);
+  _NSGetExecutablePath(file_name, &size);
 #else
   char buffer[1024];
   size_t len = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);

--- a/src/ms/mzml/mzml_ms_json_writer.cpp
+++ b/src/ms/mzml/mzml_ms_json_writer.cpp
@@ -83,7 +83,7 @@ void write(std::string &file_name, MzmlMsPtr ms_ptr, MatchEnvPtrVec &envs) {
   for (size_t i = 0; i < envs.size(); i++) {
     rapidjson::Value env(rapidjson::kObjectType);
     EnvPtr theo_env = envs[i]->getTheoEnvPtr();
-    env.AddMember("id", i, allocator);
+    env.AddMember("id", static_cast<int64_t>(i), allocator);
     env.AddMember("mono_mass", theo_env->getMonoNeutralMass(), allocator);
     env.AddMember("charge", theo_env->getCharge(), allocator);
 


### PR DESCRIPTION
## Summary
This PR adds macOS (Apple Silicon and Intel) support to TopPIC Suite and consolidates the Linux/macOS CMake configuration into a single shared block. No behavioral changes on Linux or Windows; their build commands and install layouts remain identical.

## Motivation
On a stock macOS system, `make -j$(sysctl -n hw.ncpu)` failed in the build directory with linker errors (`ld: library 'Qt5Widgets' not found`, then `symbol(s) not found for architecture arm64`). Even after the link step succeeded, the binaries failed at runtime with:
```
LOG ERROR: src/common/util/file_util.cpp[70]: The resource directory /usr/share/toppic does not exist!
LOG ERROR: src/common/util/file_util.cpp[72]: The resource directory resources does not exist!
```
The root causes were all macOS-specific:
1. Homebrew installs into `/opt/homebrew` (Apple Silicon) or `/usr/local` (Intel), neither of which is on the default compiler/linker search path that the bare-name `target_link_libraries(... boost_chrono ...)` calls rely on.
2. Homebrew's `qt@5` cannot be resolved by the bare names `Qt5Widgets/Qt5Core/Qt5Gui`.
3. `getExecutiveDir()` used the Linux-only `/proc/self/exe` path, which does not exist on macOS, so the helper returned an empty directory and the subsequent `<exec_dir>/resources` lookup failed.
4. Under Apple clang the `rapidjson::Value::AddMember("id", size_t, ...)` call was ambiguous between the `int64_t` and `uint64_t` overloads.

## Changes

### `CMakeLists.txt`

- Add an `if(APPLE)` block at the top that prepends `/opt/homebrew/include` and `/opt/homebrew/lib` to the compiler/linker search paths so the project's bare-name dependencies (`boost_*`, `xerces-c`, `sqlite3`, `zlib`, `onnxruntime`, ...) resolve via Homebrew.
- Add a Darwin install-paths block that points `CMAKE_INSTALL_BINDIR` at `/usr/local/bin` and `CMAKE_INSTALL_DATADIR` at `/usr/local/bin/resources`.
- Linux and macOS now share one identical set of `target_link_libraries` and `install` calls.
- Switch the GUI executables from bare Qt names (`Qt5Widgets Qt5Core Qt5Gui`) to the canonical imported targets (`Qt5::Widgets Qt5::Core Qt5::Gui`). The imported targets carry absolute library paths produced by `find_package(Qt5*)`, so they should work on Linux exactly as before and also resolve Homebrew's `qt@5` on macOS.
- Move the Linux-only `install(DIRECTORY lib/toppic/ ...)` into its own tiny block, since the bundled `libonnxruntime.so` is shipped only for Linux. macOS uses the system Homebrew dylib and Windows uses the bundled DLL handled in its own block.

### `src/common/util/file_util.cpp`

- `getExecutiveDir()` needs to know where the binary lives so `getResourceDir()` can locate `<exec_dir>/resources`. The existing non-Windows branch reads `/proc/self/exe`, a Linux-specific procfs entry that does not exist on macOS, so the helper returns an empty string and the lookup degenerates to the absolute fallback `/usr/share/toppic` and fails. The fix is the macOS-native equivalent `_NSGetExecutablePath` from `<mach-o/dyld.h>`. 

### `src/ms/mzml/mzml_ms_json_writer.cpp`

- The loop index `i` is `size_t`, which on macOS matches neither `int64_t` nor `uint64_t` more closely, so Apple clang refuses the `rapidjson::Value::AddMember` call as ambiguous. The IDs are small non-negative integers, so casting to `int64_t` is both safe and consistent with `rapidjson`'s own examples.

## Test coverage

- [x] Built successfully on macOS Tahoe 26.4.1
